### PR TITLE
Three things in life are certain; Death, PERFORMANCE TESTS NOT WORKING, and taxes. Until now

### DIFF
--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -572,7 +572,6 @@ const planning = {
       plan.push.apply(plan, parts) // eslint-disable-line prefer-spread
     }
 
-    // Remove phases with a 0 second duration
     return planning.resolveInvalidPhases(plan)
   },
   /**
@@ -601,7 +600,8 @@ const planning = {
    * Given a `plan`, resolves any invalid phases.
    * An invalid phase is defined as one of the following:
    *   - Any phase with a duration of `0` following another phase that contains a duration. This phase will be removed.
-   *   - Any other phases with a duration of `0` (e.g. following a pause phase). These phases will be amended to have their duration set to `1`.
+   *   - Any other phases with a duration of `0` following a pause phase. The pause phase will be replaced by the duration phase
+   *     with a duration set equal to the pause duration.
    *
    * @param plan An array of scripts to resolve
    * @returns {Array} The resolved array of scripts with invalid phases amended

--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -609,7 +609,7 @@ const planning = {
     // Update the phases in the script. If there are no phases with a duration (e.g. only `pause` phases), then remove everything
     updatedScript.config.phases = phasesWithDuration.length > 0 ? newPhases : []
     return updatedScript
-  }
+  },
 }
 
 module.exports = planning

--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -616,7 +616,7 @@ const planning = {
         return
       }
 
-      // Remove any phases with a duration of 0 that follow a phase with a duration
+      // Skip any phases with a duration of 0 that follow a phase with a duration
       // e.g.
       // { duration: 1, arrivalRate: 0, rampTo: 25 }, { duration: 0, arrivalRate: 25 }
       // Becomes
@@ -625,7 +625,7 @@ const planning = {
         return
       }
 
-      // Remove any pause phases that precede a phase with a duration of 0 - the duration phase will replace it
+      // Skip any pause phases that precede a phase with a duration of 0 - the duration phase will replace it
       // Replace a previous pause phase if a duration of 0 follows. Set the phase duration to the pause duration
       // e.g.
       // { pause: 3 }, { duration: 0, arrivalRate: 1 }

--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -549,9 +549,6 @@ const planning = {
     const plan = []
     let updatedScript = planning.ensureScriptGenesis(script, timeNow)
 
-    // Remove phases with a 0 second duration
-    updatedScript = planning.removeInvalidPhases(updatedScript)
-
     // ## Duration ##
     const scriptDurationInSeconds = planning.scriptDurationInSeconds(updatedScript)
 
@@ -575,7 +572,8 @@ const planning = {
       plan.push.apply(plan, parts) // eslint-disable-line prefer-spread
     }
 
-    return plan
+    // Remove phases with a 0 second duration
+    return planning.resolveInvalidPhases(plan)
   },
   /**
    * Plan for executing a set of samples for each unique flow in the given script where each sample
@@ -599,17 +597,57 @@ const planning = {
       _genesis: script._genesis === undefined ? timeNow : script._genesis,
     }),
 
-  removeInvalidPhases: (script) => {
-    const updatedScript = JSON.parse(JSON.stringify(script))
+  /**
+   * Given a `plan`, resolves any invalid phases.
+   * An invalid phase is defined as one of the following:
+   *   - Any phase with a duration of `0` following another phase that contains a duration. This phase will be removed.
+   *   - Any other phases with a duration of `0` (e.g. following a pause phase). These phases will be amended to have their duration set to `1`.
+   *
+   * @param plan An array of scripts to resolve
+   * @returns {Array} The resolved array of scripts with invalid phases amended
+   */
+  resolveInvalidPhases: (plan) => plan.map((script) => {
+    const newPhases = []
+    script.config.phases
+      .forEach((thisPhase, index) => {
+        const prevPhase = script.config.phases[index - 1]
+        const nextPhase = script.config.phases[index + 1]
+        if (thisPhase.duration > 0) {
+          newPhases.push(thisPhase)
+          return
+        }
 
-    // Remove phases that have explicitly set a duration to 0
-    const newPhases = updatedScript.config.phases.filter(phase => !('duration' in phase) || phase.duration > 0)
-    const phasesWithDuration = updatedScript.config.phases.filter(phase => 'duration' in phase)
+        // Remove any phases with a duration of 0 that follow a phase with a duration
+        // e.g.
+        // { duration: 1, arrivalRate: 0, rampTo: 25 }, { duration: 0, arrivalRate: 25 }
+        // Becomes
+        // { duration: 1, arrivalRate: 0, rampTo: 25 }
+        if (prevPhase && prevPhase.duration >= 0 && thisPhase.duration === 0) {
+          return
+        }
 
-    // Update the phases in the script. If there are no phases with a duration (e.g. only `pause` phases), then remove everything
-    updatedScript.config.phases = phasesWithDuration.length > 0 ? newPhases : []
-    return updatedScript
-  },
+        // Remove any pause phases that precede a phase with a duration of 0 - the duration phase will replace it
+        // Replace a previous pause phase if a duration of 0 follows. Set the phase duration to the pause duration
+        // e.g.
+        // { pause: 3 }, { duration: 0, arrivalRate: 1 }
+        // Becomes
+        // { duration: 3, arrivalRate: 1 }
+        if (nextPhase && nextPhase.duration === 0 && thisPhase.pause) {
+          return
+        }
+        if (prevPhase && prevPhase.pause && thisPhase.duration === 0) {
+          thisPhase.duration = prevPhase.pause // eslint-disable-line no-param-reassign
+          newPhases.push(thisPhase)
+          return
+        }
+
+        // Valid phase if we've made it here
+        newPhases.push(thisPhase)
+      })
+
+    script.config.phases = newPhases // eslint-disable-line no-param-reassign
+    return script
+  }),
 }
 
 module.exports = planning

--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -608,42 +608,41 @@ const planning = {
    */
   resolveInvalidPhases: (plan) => plan.map((script) => {
     const newPhases = []
-    script.config.phases
-      .forEach((thisPhase, index) => {
-        const prevPhase = script.config.phases[index - 1]
-        const nextPhase = script.config.phases[index + 1]
-        if (thisPhase.duration > 0) {
-          newPhases.push(thisPhase)
-          return
-        }
-
-        // Remove any phases with a duration of 0 that follow a phase with a duration
-        // e.g.
-        // { duration: 1, arrivalRate: 0, rampTo: 25 }, { duration: 0, arrivalRate: 25 }
-        // Becomes
-        // { duration: 1, arrivalRate: 0, rampTo: 25 }
-        if (prevPhase && prevPhase.duration >= 0 && thisPhase.duration === 0) {
-          return
-        }
-
-        // Remove any pause phases that precede a phase with a duration of 0 - the duration phase will replace it
-        // Replace a previous pause phase if a duration of 0 follows. Set the phase duration to the pause duration
-        // e.g.
-        // { pause: 3 }, { duration: 0, arrivalRate: 1 }
-        // Becomes
-        // { duration: 3, arrivalRate: 1 }
-        if (nextPhase && nextPhase.duration === 0 && thisPhase.pause) {
-          return
-        }
-        if (prevPhase && prevPhase.pause && thisPhase.duration === 0) {
-          thisPhase.duration = prevPhase.pause // eslint-disable-line no-param-reassign
-          newPhases.push(thisPhase)
-          return
-        }
-
-        // Valid phase if we've made it here
+    script.config.phases.forEach((thisPhase, index) => {
+      const prevPhase = script.config.phases[index - 1]
+      const nextPhase = script.config.phases[index + 1]
+      if (thisPhase.duration > 0) {
         newPhases.push(thisPhase)
-      })
+        return
+      }
+
+      // Remove any phases with a duration of 0 that follow a phase with a duration
+      // e.g.
+      // { duration: 1, arrivalRate: 0, rampTo: 25 }, { duration: 0, arrivalRate: 25 }
+      // Becomes
+      // { duration: 1, arrivalRate: 0, rampTo: 25 }
+      if (prevPhase && prevPhase.duration >= 0 && thisPhase.duration === 0) {
+        return
+      }
+
+      // Remove any pause phases that precede a phase with a duration of 0 - the duration phase will replace it
+      // Replace a previous pause phase if a duration of 0 follows. Set the phase duration to the pause duration
+      // e.g.
+      // { pause: 3 }, { duration: 0, arrivalRate: 1 }
+      // Becomes
+      // { duration: 3, arrivalRate: 1 }
+      if (nextPhase && nextPhase.duration === 0 && thisPhase.pause) {
+        return
+      }
+      if (prevPhase && prevPhase.pause && thisPhase.duration === 0) {
+        thisPhase.duration = prevPhase.pause // eslint-disable-line no-param-reassign
+        newPhases.push(thisPhase)
+        return
+      }
+
+      // Valid phase if we've made it here
+      newPhases.push(thisPhase)
+    })
 
     script.config.phases = newPhases // eslint-disable-line no-param-reassign
     return script

--- a/lib/lambda/planning.js
+++ b/lib/lambda/planning.js
@@ -549,6 +549,9 @@ const planning = {
     const plan = []
     let updatedScript = planning.ensureScriptGenesis(script, timeNow)
 
+    // Remove phases with a 0 second duration
+    updatedScript = planning.removeInvalidPhases(updatedScript)
+
     // ## Duration ##
     const scriptDurationInSeconds = planning.scriptDurationInSeconds(updatedScript)
 
@@ -595,6 +598,18 @@ const planning = {
     Object.assign(script, {
       _genesis: script._genesis === undefined ? timeNow : script._genesis,
     }),
+
+  removeInvalidPhases: (script) => {
+    const updatedScript = JSON.parse(JSON.stringify(script))
+
+    // Remove phases that have explicitly set a duration to 0
+    const newPhases = updatedScript.config.phases.filter(phase => !('duration' in phase) || phase.duration > 0)
+    const phasesWithDuration = updatedScript.config.phases.filter(phase => 'duration' in phase)
+
+    // Update the phases in the script. If there are no phases with a duration (e.g. only `pause` phases), then remove everything
+    updatedScript.config.phases = phasesWithDuration.length > 0 ? newPhases : []
+    return updatedScript
+  }
 }
 
 module.exports = planning

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bom-serverless-artillery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A serverless performance testing tool. `serverless` + `artillery` = crush.  a.k.a. Orbital Laziers [sic]",
   "main": "index.js",
   "bin": {

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -33,6 +33,7 @@ const awaitScriptDuration = script =>
 //  sorted by timestamp earliest -> latest
 const fetchListOfCalls = async ({ listUrl }) => {
   let retryCount = 10
+  let interval = 50
   while (retryCount > 0) {
     try {
       const response = await fetch(listUrl)
@@ -40,8 +41,9 @@ const fetchListOfCalls = async ({ listUrl }) => {
       return JSON.parse(json)
     } catch (err) {
       log('request for list of calls failed:', err.stack)
+      await new Promise((resolve) => { setTimeout(resolve, interval) })
       retryCount -= 1
-      await new Promise((resolve) => { setTimeout(resolve, 1000) })
+      interval *= 2
     }
   }
 

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -41,7 +41,7 @@ const fetchListOfCalls = async ({ listUrl }) => {
       return JSON.parse(json)
     } catch (err) {
       log('request for list of calls failed:', err.stack)
-      await new Promise((resolve) => { setTimeout(resolve, interval) })
+      await new Promise((resolve) => { setTimeout(resolve, interval) }) // eslint-disable-line no-loop-func
       retryCount -= 1
       interval *= 2
     }

--- a/tests/integration/target/serverless.yml
+++ b/tests/integration/target/serverless.yml
@@ -22,6 +22,7 @@ functions:
 
   list:
     handler: handler.list
+    timeout: 30
     events:
       - http:
           path: list/{id}

--- a/tests/lib/lambda/planning.spec.js
+++ b/tests/lib/lambda/planning.spec.js
@@ -1245,6 +1245,33 @@ describe('./lib/lambda/taskPlan.js', () => {
         expect(planning.splitScriptByRequestsPerSecondAndSchedule).to.have.been.called.with.exactly(1, chunk, defaultSettings)
         expect(result.length).to.equal(3)
       })
+      it('correctly adjusts phases with a duration of 0 (intersection.x === phase.duration)', () => {
+        sandbox.restore()
+        script.config.phases = [
+          { duration: 1, arrivalRate: 0, rampTo: 26 },
+        ]
+        const expectedPhases1 = [
+          { duration: 1, arrivalRate: 1, rampTo: 25 },
+        ]
+        const expectedPhases2 = [
+          { duration: 1, arrivalRate: 1 },
+        ]
+        result = planning.planPerformance(1, script, defaultSettings)
+        console.log(JSON.stringify(result, null, 2))
+        expect(result.length).to.equal(2)
+        expect(result[0].config.phases).to.eql(expectedPhases1)
+        expect(result[1].config.phases).to.eql(expectedPhases2)
+      })
+      it('correctly adjusts phases with a duration of 0 (real-world case)', () => {
+        sandbox.restore()
+        script.config.phases = [
+          { duration: 300, arrivalRate: 0, rampTo: 3380 },
+          { duration: 120, arrivalRate: 3380 },
+        ]
+        result = planning.planPerformance(1, script, defaultSettings)
+        expect(result.length).to.be.above(0)
+        result.forEach(rs => rs.config.phases.forEach(rp => expect(rp.duration).not.to.equal(0)))
+      })
     })
 
     describe('#planSamples', () => {
@@ -1280,6 +1307,7 @@ describe('./lib/lambda/taskPlan.js', () => {
         ]
         // Split #1
         result = planning.planPerformance(0, script, defaultSettings)
+        console.log(JSON.stringify(result, null, 2))
         expect(result).to.be.eql(expected)
         expected = [
           { config: { phases: [{ duration: 660, arrivalRate: 147, rampTo: 1 }] }, _genesis: 0, _start: 255000 },

--- a/tests/lib/lambda/planning.spec.js
+++ b/tests/lib/lambda/planning.spec.js
@@ -1258,7 +1258,7 @@ describe('./lib/lambda/taskPlan.js', () => {
         ]
         // NOTE: Prior to implementing the fix to resolve invalid phases, the `expectedPhases2` would have looked like:
         // [ { pause: 1 }, { duration: 0, arrivalRate: 1 }]
-        // This would cause the lambda to run infinitely
+        // This would cause the lambda to run indefinitely
         result = planning.planPerformance(1, script, defaultSettings)
         console.log(JSON.stringify(result, null, 2))
         expect(result.length).to.equal(2)

--- a/tests/lib/lambda/planning.spec.js
+++ b/tests/lib/lambda/planning.spec.js
@@ -1256,6 +1256,9 @@ describe('./lib/lambda/taskPlan.js', () => {
         const expectedPhases2 = [
           { duration: 1, arrivalRate: 1 },
         ]
+        // NOTE: Prior to implementing the fix to resolve invalid phases, the `expectedPhases2` would have looked like:
+        // [ { pause: 1 }, { duration: 0, arrivalRate: 1 }]
+        // This would cause the lambda to run infinitely
         result = planning.planPerformance(1, script, defaultSettings)
         console.log(JSON.stringify(result, null, 2))
         expect(result.length).to.equal(2)


### PR DESCRIPTION
## Reason for change

The moment you've all been waiting for....
I present to you:

**Part 1 of a 2 part series called: FIXING THE DAMN PERFORMANCE TEST**

This part includes identification and resolution of a deeply buried serverless-artillery bug where a duration of `0` can occassionally be assigned to a load phase in some circumstances. This causes artillery to run it for an 'infinite' duration, timing out the lambda and this is what we see in the performance test error logs after a performance test has been run, partcularly for api-forecasts-town and api-observations.

I think it has something to do with specific durations that we specify in the performance test config, because it obviously only happens for a specific set of APIs, and other APIs operate perfectly fine.

For a more detailed explanation:
**UPDATE:** Upon further investigation, I found that the simplest configuration to cause this issue is:
```yml
duration: 1
arrivalRate: 0
rampTo: 26
```
The reason this happens is because the maximum RPS per lambda (chunk) is 25. When serverless-artillery tries to break this down, it performs a line intersection between the ramp phase: { x: 0, y: 0 ), { x: 1, y: 26 } and a limit: { x: 0, y: 25 }, { x: 1, y: 25 }
This returns an intersection point of (0.96..., 25), which is then rounded to (1, 25).
You will notice the the X value for the intersection point is equal to the duration of the phase. This is where the problem comes in, as the calculation performed to split the phase actually subtracts the x intersection point from the duration, resulting in a duration value of 0.


serverless-artillery restricts lambda invocations to 120s. Obviously, when we specify durations longer than this in our config (e.g 5min  ramp up from 0 to 3000 RPS), serverless-artillery needs to split the work up (and the load, because a single lambda cant do 3000 RPS). To achieve this, it recursively breaks down the phase until each 'chunk' is within pre-defined limits, set in lib/lambda/platform-settings.js.
Depending at what point in the 120s the lambda needs to execute it's load, serverless-artillery will add a series of `pause` phases. This is done recursively, so when you get to a lambda that is supposed to execute its load at the end of the 120s period, if you log the phases in that lambda you will see a whole bunch of 2 or 3 second `pause` phases before the actual load phase is defined.
The problem is, in some very rare cases, the `pause` phases (and sometimes a final ramp up phase) will exhaust the entire 120s of restricted runtime (this is just imposed by serverless-artillery, the lambda timeout is still 300s).
This can cause a final phase to be added which has a duration of `0`, because the amount left to ramp up or down to is 25 <= x < 30. When this happens, it seems that `artillery` doesn't really know what to do, and takes it as an infinite duration, causing the lambda to timeout.

The fix I have implemented is to remove any phases with a duration of 0 that follow a duration phase, and then replace a `pause` phase with the following duration phase if it has a duration of 0.
You can see some examples of this in the code comments, and I've added a test.

Unfortunately the original serverless-artillery repository has probably been private-d (it is a 404 now), and I was hoping an issue had been opened against this because it seems like it would be a fairly common issue - unless we've somehow managed to pick the few durations that recursively get reduced down to a phase with a 0 duration....

Ticket:

This is a:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change)
- [ ] New or improved tests (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality or implements non-functional requirement)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation or design proposal


## Checklist

- [ ] This PR has a descriptive title
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and docs have been updated.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change requires an Akamai change.  Cherwell ticket number is in Reason for Change.
- [ ] This needs a change request.  CR# is in title.
